### PR TITLE
Add supporters page

### DIFF
--- a/content/icons/arrow_outward.svg
+++ b/content/icons/arrow_outward.svg
@@ -1,0 +1,8 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <mask id="mask0_189_13326" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="32" height="32">
+    <rect width="32" height="32" fill="#D9D9D9"/>
+  </mask>
+  <g mask="url(#mask0_189_13326)">
+    <path d="M8.53268 23.9993L6.66602 22.1327L19.466 9.33268H7.99935V6.66602H23.9993V22.666H21.3327V11.1993L8.53268 23.9993Z" fill="#D9D9D9"/>
+  </g>
+</svg>

--- a/content/index.html
+++ b/content/index.html
@@ -2,7 +2,9 @@
   <div class="container_">
     <div class="flex h-14 shrink grow basis-0 items-center justify-between gap-6">
       <div class="flex grow flex-col items-start justify-self-start md:w-40">
-        <img class="h-6" src="logo.svg" />
+        <a href="/">
+          <img class="h-6" src="logo.svg" />
+        </a>
       </div>
 
       <button class="h-14 w-14 md:hidden" onclick="toggleNavigation()" id="navigation-open">
@@ -25,7 +27,7 @@
 
       <div class="hidden items-center justify-start gap-10 text-md font-normal leading-normal text-black md:flex">
         <!-- <div>For participants</div> -->
-        <!-- <div>For supporters</div> -->
+        <a class="text-black text-base font-normal leading-normal" href="/supporters"">For supporters</a>
         <!-- <div>For volunteers</div> -->
         <!-- <div>Agenda</div> -->
         <!-- <div>Buy ticket</div> -->
@@ -42,7 +44,7 @@
 <div class="container_ pointer-events-auto hidden" id="navigation">
   <div class="flex flex-col items-start justify-start gap-8 bg-white px-8 py-12 text-md font-normal leading-normal text-black">
     <!-- <div>For participants</div> -->
-    <!-- <div>For supporters</div> -->
+    <a class="text-black text-base font-normal leading-normal" href="/supporters" onclick="toggleNavigation()">For supporters</a>
     <!-- <div>For volunteers</div> -->
     <!-- <div>Agenda</div> -->
     <!-- <div>Buy ticket</div> -->

--- a/content/supporters.html
+++ b/content/supporters.html
@@ -1,0 +1,276 @@
+<div class="pointer-events-auto h-24 items-center justify-center gap-40 border-b border-red-logo/30 bg-white py-5">
+  <div class="container_">
+    <div class="flex h-14 shrink grow basis-0 items-center justify-between gap-6">
+      <div class="flex grow flex-col items-start justify-self-start md:w-40">
+        <a href="/">
+          <img class="h-6" src="/logo.svg" />
+        </a>
+      </div>
+
+      <button class="h-14 w-14 md:hidden" onclick="toggleNavigation()" id="navigation-open">
+        <svg width="56" height="56" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M0.5 1H55.5V56H0.5V1Z" fill="black" />
+          <path d="M0.5 1H55.5V56H0.5V1Z" stroke="black" />
+          <path d="M37 24.25H19C18.59 24.25 18.25 23.91 18.25 23.5C18.25 23.09 18.59 22.75 19 22.75H37C37.41 22.75 37.75 23.09 37.75 23.5C37.75 23.91 37.41 24.25 37 24.25Z" fill="white" />
+          <path d="M37 29.25H19C18.59 29.25 18.25 28.91 18.25 28.5C18.25 28.09 18.59 27.75 19 27.75H37C37.41 27.75 37.75 28.09 37.75 28.5C37.75 28.91 37.41 29.25 37 29.25Z" fill="white" />
+          <path d="M37 34.25H19C18.59 34.25 18.25 33.91 18.25 33.5C18.25 33.09 18.59 32.75 19 32.75H37C37.41 32.75 37.75 33.09 37.75 33.5C37.75 33.91 37.41 34.25 37 34.25Z" fill="white" />
+        </svg>
+      </button>
+
+      <button class="hidden h-14 w-14 md:hidden" onclick="toggleNavigation()" id="navigation-close">
+        <svg width="56" height="56" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <path d="M0.5 0.5H55.5V55.5H0.5V0.5Z" fill="black" />
+          <path d="M0.5 0.5H55.5V55.5H0.5V0.5Z" stroke="black" />
+          <path d="M22.4 35L21 33.6L26.6 28L21 22.4L22.4 21L28 26.6L33.6 21L35 22.4L29.4 28L35 33.6L33.6 35L28 29.4L22.4 35Z" fill="white" />
+        </svg>
+      </button>
+
+      <div class="hidden items-center justify-start gap-10 text-md font-normal leading-normal text-black md:flex">
+        <!-- <div>For participants</div> -->
+        <a class="text-black text-base font-normal leading-normal" href="/supporters"">For supporters</a>
+        <!-- <div>For volunteers</div> -->
+        <!-- <div>Agenda</div> -->
+        <!-- <div>Buy ticket</div> -->
+        <a href="mailto:all@wrocloverb.com">Contact</a>
+        <!-- <div>FAQ</div> -->
+      </div>
+      <div class="button_ hidden md:flex">
+        <a href="https://forms.gle/ovGZU4hNUdPVq7mPA" class="text-lg font-bold leading-relaxed text-white">Call for papers</a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="container_ pointer-events-auto hidden" id="navigation">
+  <div class="flex flex-col items-start justify-start gap-8 bg-white px-8 py-12 text-md font-normal leading-normal text-black">
+    <!-- <div>For participants</div> -->
+    <a class="text-black text-base font-normal leading-normal" href="/supporters" onclick="toggleNavigation()">For supporters</a>
+    <!-- <div>For volunteers</div> -->
+    <!-- <div>Agenda</div> -->
+    <!-- <div>Buy ticket</div> -->
+    <a href="mailto:all@wrocloverb.com">Contact</a>
+    <!-- <div>FAQ</div> -->
+  </div>
+</div>
+
+<div class="linear-gradient-r relative">
+  <div class="container_ py-20">
+    <div class="flex flex-col items-start justify-center gap-8 self-stretch py-8 lg:max-w-[720px]">
+      <div class="z-10 flex flex-col items-start justify-start gap-5 self-stretch">
+        <div class="flex flex-col items-start justify-start gap-5 self-stretch">
+          <div class="flex flex-col items-start justify-start gap-3 self-stretch">
+            <div class="pointer-events-auto self-stretch text-[40px] font-bold uppercase leading-[1.1] tracking-tighter text-grey-logo md:text-5xl md:leading-[1.125] md:tracking-tight">BECOME supporter</div>
+          </div>
+          <div class="pointer-events-auto self-stretch font-inter text-md font-medium leading-normal text-grey-600">
+            Help nurture the Ruby community by becoming a wroc_love.rb supporter. Your contribution enables us to create a space for knowledge sharing and innovation, fostering the growth of Ruby professionals and the technology we all love.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="h-52 sm:h-32 bg-black justify-between items-center inline-flex w-full">
+  <div class="container_">
+    <div class="h-10 justify-between items-center flex flex-col sm:flex-row">
+      <div class="text-white text-2xl font-medium font-inter leading-10">Contact us by e-mail:</div>
+      <div class="justify-start items-center gap-3 flex sm:gap-4 sm:inline-flex">
+        <div class="pointer-events-auto text-white text-2xl md:text-3xl font-light font-inter italic leading-7 sm:leading-10">
+          <a href="mailto:all@wrocloverb.com">all@wrocloverb.com</a>
+        </div>
+        <div class="w-6 sm:w-8 h-6 sm:h-8 relative">
+          <div class="w-6 sm:w-8 h-6 sm:h-8">
+            <img src="/icons/arrow_outward.svg" />
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="container_">
+  <div class="py-20 flex-col justify-start items-center gap-8 inline-flex">
+    <div class="self-stretch flex-col justify-start items-start gap-8 flex">
+      <div class="flex-col justify-start items-start gap-4 flex">
+        <div class="text-grey-logo text-4xl font-bold font-overpass leading-10">What we offer</div>
+      </div>
+      <div class="flex flex-col items-start justify-start gap-16 self-stretch">
+        <div class="flex shrink grow basis-0 flex-col items-start justify-start gap-5 self-stretch md:flex-row md:gap-5">
+          <div class="flex min-h-[220px] flex-col items-start justify-start gap-2 sm:min-h-[160px] md:min-h-[220px] md:w-1/3">
+            <div class="flex grow items-center justify-start gap-4 self-stretch border border-red-logo/30 bg-white/40 p-4">
+              <div class="flex shrink grow basis-0 flex-col items-end justify-start gap-4 self-stretch">
+                <div class="flex shrink grow basis-0 flex-col items-start justify-start gap-4 self-stretch">
+                  <div class="flex flex-col items-start justify-start gap-2 self-stretch">
+                    <div class="self-stretch text-2xl font-bold leading-normal text-grey-logo">Company visibility</div>
+                  </div>
+                  <div class="shrink grow basis-0 self-stretch font-inter text-sm font-normal leading-tight text-grey-600">
+                    We will publish information about you being a supporter on our social media. Your company will be visible on post-conference videos, in the conference room between the talks and on our website in the supporters section, alongside with a link.
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="mt-0 flex min-h-[220px] flex-col items-start justify-start gap-2 sm:min-h-[160px] md:mt-8 md:min-h-[220px] md:w-1/3">
+            <div class="flex grow flex-col items-start justify-start gap-2 self-stretch">
+              <div class="flex grow flex-col items-start justify-center gap-4 self-stretch border border-red-logo/30 bg-white/40 p-4">
+                <div class="flex shrink grow basis-0 flex-col items-end justify-start gap-4 self-stretch">
+                  <div class="flex shrink grow basis-0 flex-col items-start justify-start gap-4 self-stretch">
+                    <div class="flex flex-col items-start justify-start gap-2 self-stretch">
+                      <div class="self-stretch text-2xl font-bold leading-normal text-grey-logo">Communication channel with participants</div>
+                    </div>
+                    <div class="shrink grow basis-0 self-stretch font-inter text-sm font-normal leading-tight text-grey-600">
+                      You will have your own channel on our Discord server, where participants can engage with your company representatives. Note that being present on Discord is not mandatory so likely not all participants will be there, although we will encourage it.
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="flex min-h-[220px] flex-col items-start justify-start gap-2 sm:min-h-[160px] md:min-h-[220px] md:w-1/3">
+            <div class="flex shrink grow basis-0 flex-col items-start justify-center gap-4 self-stretch border border-red-logo/30 bg-white/40 p-4">
+              <div class="flex shrink grow basis-0 flex-col items-end justify-start gap-4 self-stretch">
+                <div class="flex shrink grow basis-0 flex-col items-start justify-start gap-4 self-stretch">
+                  <div class="flex flex-col items-start justify-start gap-2 self-stretch">
+                    <div class="self-stretch text-2xl font-bold leading-normal text-grey-logo">Tickets</div>
+                  </div>
+                  <div class="shrink grow basis-0 self-stretch font-inter text-sm font-normal leading-tight text-grey-600">
+                    Buying Supporter Ticket already grants permission to enter the conference for 1 person, with a distinctive badge, which may help with networking :) Additionally, if tickets run out we guarantee an option to buy three additional tickets outside the regular ticket batches.
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="container_ flex flex-col">
+  <div class="min-h-44 sm:min-h-80 py-20 bg-white flex-col justify-center sm:justify-start items-start sm:items-center gap-3 sm:gap-8 inline-flex overflow-hidden">
+    <div class="justify-start items-center gap-12 inline-flex flex-col sm:flex-row">
+      <div class="text-[#151314] text-3xl font-bold font-overpass leading-10">Thank you to our supporters</div>
+      <div class="text-grey-400 text-3xl font-bold font-inter hidden sm:block">|</div>
+      <div class="text-[#151314] text-2xl font-medium font-overpass leading-loose">Do you want to be on the list? Click here to support us!</div>
+    </div>
+    <div class="flex flex-wrap items-center justify-center gap-16 self-stretch px-10 py-6">
+      <a href="https://arkency.com">
+        <img class="h-9" src="/supporters/arkency.svg" />
+      </a>
+      <a href="https://ii.uni.wroc.pl">
+        <img class="h-12" src="/partners/uwr.svg" />
+      </a>
+      <a href="https://pragprog.com">
+        <img class="h-9" src="/partners/pragmatic_bookshelf.png" />
+      </a>
+      <a href="https://rubycommunityconference.com">
+        <img class="h-9" src="/partners/rwcc.png" />
+      </a>
+      <a href="https://www.railschangelog.com">
+        <img class="h-12" src="/partners/rails_changelog.png" />
+      </a>
+    </div>
+  </div>
+</div>
+
+<div class="linear-gradient-l pointer-events-auto flex items-center justify-start py-10">
+  <div class="container_">
+    <div class="flex flex-col items-start justify-between gap-6 self-stretch md:flex-row md:items-center">
+      <div class="h-6">
+        <img class="h-6 self-stretch" src="/logo.svg" />
+      </div>
+      <div class="grid grid-cols-2 items-start justify-start self-stretch md:flex md:items-center">
+        <!-- <div class="flex items-start justify-start gap-4 px-6 py-3 md:items-center md:justify-center">
+              <div class="text-md font-normal leading-normal text-black">For participants</div>
+            </div> -->
+        <!-- <div class="flex items-start justify-start gap-4 px-6 py-3 md:items-center md:justify-center">
+              <div class="text-md font-normal leading-normal text-black">For supporters</div>
+            </div> -->
+        <div class="flex items-start justify-start gap-4 px-6 py-3 md:items-center md:justify-center">
+          <a href="https://forms.gle/ovGZU4hNUdPVq7mPA" class="text-md font-normal leading-normal text-black">Call for papers</a>
+        </div>
+        <!-- <div class="flex items-start justify-start gap-4 px-6 py-3 md:items-center md:justify-center">
+              <div class="text-md font-normal leading-normal text-black">Buy ticket</div>
+            </div> -->
+        <div class="flex items-start justify-start gap-4 px-6 py-3 md:items-center md:justify-center">
+          <a href="mailto:all@wrocloverb.com" class="text-md font-normal leading-normal text-black">Contact</a>
+        </div>
+        <!-- <div class="flex items-start justify-start gap-4 px-6 py-3 md:items-center md:justify-center">
+              <div class="text-md font-normal leading-normal text-black">FAQ</div>
+            </div> -->
+      </div>
+    </div>
+    <div class="mt-8 flex flex-col items-start justify-between self-stretch md:flex-row md:items-center">
+      <div class="flex items-center justify-start gap-6">
+        <div class="flex items-center justify-center gap-4 py-3">
+          <a href="https://docs.google.com/document/d/1RzFxAu0yflAEPsKHzSE5dmGowl5LAih4W6j3_CLAohY/edit?usp=sharing" class="text-md font-normal leading-normal text-grey-600">Terms of service</a>
+        </div>
+        <div class="flex items-center justify-center gap-4 py-3">
+          <a href="https://docs.google.com/document/d/1UQIeUTJeW3qbvzB8Sx-G-Ow0qbM4GgzMKkQk66UBz5M/edit?usp=sharing" class="text-md font-normal leading-normal text-grey-600">Code of conduct</a>
+        </div>
+      </div>
+      <div class="mt-4 flex items-center justify-start gap-6 fill-grey-600 md:mt-0">
+        <div class="h-6 w-6">
+          <a href="https://discord.com/invite/UYMestkPNc">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512">
+              <path
+                d="M524.5 69.8a1.5 1.5 0 0 0 -.8-.7A485.1 485.1 0 0 0 404.1 32a1.8 1.8 0 0 0 -1.9 .9 337.5 337.5 0 0 0 -14.9 30.6 447.8 447.8 0 0 0 -134.4 0 309.5 309.5 0 0 0 -15.1-30.6 1.9 1.9 0 0 0 -1.9-.9A483.7 483.7 0 0 0 116.1 69.1a1.7 1.7 0 0 0 -.8 .7C39.1 183.7 18.2 294.7 28.4 404.4a2 2 0 0 0 .8 1.4A487.7 487.7 0 0 0 176 479.9a1.9 1.9 0 0 0 2.1-.7A348.2 348.2 0 0 0 208.1 430.4a1.9 1.9 0 0 0 -1-2.6 321.2 321.2 0 0 1 -45.9-21.9 1.9 1.9 0 0 1 -.2-3.1c3.1-2.3 6.2-4.7 9.1-7.1a1.8 1.8 0 0 1 1.9-.3c96.2 43.9 200.4 43.9 295.5 0a1.8 1.8 0 0 1 1.9 .2c2.9 2.4 6 4.9 9.1 7.2a1.9 1.9 0 0 1 -.2 3.1 301.4 301.4 0 0 1 -45.9 21.8 1.9 1.9 0 0 0 -1 2.6 391.1 391.1 0 0 0 30 48.8 1.9 1.9 0 0 0 2.1 .7A486 486 0 0 0 610.7 405.7a1.9 1.9 0 0 0 .8-1.4C623.7 277.6 590.9 167.5 524.5 69.8zM222.5 337.6c-29 0-52.8-26.6-52.8-59.2S193.1 219.1 222.5 219.1c29.7 0 53.3 26.8 52.8 59.2C275.3 311 251.9 337.6 222.5 337.6zm195.4 0c-29 0-52.8-26.6-52.8-59.2S388.4 219.1 417.9 219.1c29.7 0 53.3 26.8 52.8 59.2C470.7 311 447.5 337.6 417.9 337.6z" />
+            </svg>
+          </a>
+        </div>
+        <div class="h-6 w-6">
+          <a href="https://www.youtube.com/user/wrocloverb">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512">
+              <path
+                d="M549.7 124.1c-6.3-23.7-24.8-42.3-48.3-48.6C458.8 64 288 64 288 64S117.2 64 74.6 75.5c-23.5 6.3-42 24.9-48.3 48.6-11.4 42.9-11.4 132.3-11.4 132.3s0 89.4 11.4 132.3c6.3 23.7 24.8 41.5 48.3 47.8C117.2 448 288 448 288 448s170.8 0 213.4-11.5c23.5-6.3 42-24.2 48.3-47.8 11.4-42.9 11.4-132.3 11.4-132.3s0-89.4-11.4-132.3zm-317.5 213.5V175.2l142.7 81.2-142.7 81.2z" />
+            </svg>
+          </a>
+        </div>
+        <div class="h-6 w-6">
+          <a href="https://ruby.social/@wrocloverb">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
+              <path
+                d="M433 179.1c0-97.2-63.7-125.7-63.7-125.7-62.5-28.7-228.6-28.4-290.5 0 0 0-63.7 28.5-63.7 125.7 0 115.7-6.6 259.4 105.6 289.1 40.5 10.7 75.3 13 103.3 11.4 50.8-2.8 79.3-18.1 79.3-18.1l-1.7-36.9s-36.3 11.4-77.1 10.1c-40.4-1.4-83-4.4-89.6-54a102.5 102.5 0 0 1 -.9-13.9c85.6 20.9 158.7 9.1 178.8 6.7 56.1-6.7 105-41.3 111.2-72.9 9.8-49.8 9-121.5 9-121.5zm-75.1 125.2h-46.6v-114.2c0-49.7-64-51.6-64 6.9v62.5h-46.3V197c0-58.5-64-56.6-64-6.9v114.2H90.2c0-122.1-5.2-147.9 18.4-175 25.9-28.9 79.8-30.8 103.8 6.1l11.6 19.5 11.6-19.5c24.1-37.1 78.1-34.8 103.8-6.1 23.7 27.3 18.4 53 18.4 175z" />
+            </svg>
+          </a>
+        </div>
+
+        <div class="h-6 w-6">
+          <a href="https://bsky.app/profile/wrocloverb.com">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+              <path
+                d="M111.8 62.2C170.2 105.9 233 194.7 256 242.4c23-47.6 85.8-136.4 144.2-180.2c42.1-31.6 110.3-56 110.3 21.8c0 15.5-8.9 130.5-14.1 149.2C478.2 298 412 314.6 353.1 304.5c102.9 17.5 129.1 75.5 72.5 133.5c-107.4 110.2-154.3-27.6-166.3-62.9l0 0c-1.7-4.9-2.6-7.8-3.3-7.8s-1.6 3-3.3 7.8l0 0c-12 35.3-59 173.1-166.3 62.9c-56.5-58-30.4-116 72.5-133.5C100 314.6 33.8 298 15.7 233.1C10.4 214.4 1.5 99.4 1.5 83.9c0-77.8 68.2-53.4 110.3-21.8z" />
+            </svg>
+          </a>
+        </div>
+
+        <div class="h-6 w-6">
+          <a href="https://x.com/wrocloverb">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
+              <path
+                d="M64 32C28.7 32 0 60.7 0 96V416c0 35.3 28.7 64 64 64H384c35.3 0 64-28.7 64-64V96c0-35.3-28.7-64-64-64H64zm297.1 84L257.3 234.6 379.4 396H283.8L209 298.1 123.3 396H75.8l111-126.9L69.7 116h98l67.7 89.5L313.6 116h47.5zM323.3 367.6L153.4 142.9H125.1L296.9 367.6h26.3z" />
+            </svg>
+          </a>
+        </div>
+
+        <div class="h-6 w-6">
+          <a href="https://www.linkedin.com/company/wroclove-rb/">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
+              <path
+                d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z" />
+            </svg>
+          </a>
+        </div>
+
+        <div class="h-6 w-6">
+          <a href="https://www.facebook.com/wroclove.rb">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
+              <path
+                d="M64 32C28.7 32 0 60.7 0 96V416c0 35.3 28.7 64 64 64h98.2V334.2H109.4V256h52.8V222.3c0-87.1 39.4-127.5 125-127.5c16.2 0 44.2 3.2 55.7 6.4V172c-6-.6-16.5-1-29.6-1c-42 0-58.2 15.9-58.2 57.2V256h83.6l-14.4 78.2H255V480H384c35.3 0 64-28.7 64-64V96c0-35.3-28.7-64-64-64H64z" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/content/supporters.html
+++ b/content/supporters.html
@@ -151,7 +151,9 @@
     <div class="justify-start items-center gap-12 inline-flex flex-col sm:flex-row">
       <div class="text-[#151314] text-3xl font-bold font-overpass leading-10">Thank you to our supporters</div>
       <div class="text-grey-400 text-3xl font-bold font-inter hidden sm:block">|</div>
-      <div class="text-[#151314] text-2xl font-medium font-overpass leading-loose">Do you want to be on the list? Click here to support us!</div>
+      <div class="text-[#151314] text-2xl font-medium font-overpass leading-loose pointer-events-auto">
+        <a href="mailto:all@wrocloverb.com">Do you want to be on the list? Click here to support us!</a>
+      </div>
     </div>
     <div class="flex flex-wrap items-center justify-center gap-16 self-stretch px-10 py-6">
       <a href="https://arkency.com">


### PR DESCRIPTION
Add basic supporters page (there's a background image missing and some sections like FAQ).

"Outer" HTML is based on the `index.html` and it's copy-pasted in naive way (header and footer are copy-pasted from `index.html`).

Make the wroclove.rb logo in the header clickable so that it always routes to the home page.

**Web screenshots:**
<img width="1763" alt="Screenshot 2025-02-06 at 10 34 07" src="https://github.com/user-attachments/assets/649bcdb9-7071-4d78-85fe-5eb254082826" />
<img width="1792" alt="Screenshot 2025-02-06 at 10 33 16" src="https://github.com/user-attachments/assets/290d67e5-ec1e-4c0a-abe0-2b78d4d82b7f" />


**Mobile screenshots:**
<img width="516" alt="Screenshot 2025-02-05 at 18 22 34" src="https://github.com/user-attachments/assets/ca5f6c57-6d23-423c-a885-a8bd1996a817" />

